### PR TITLE
original_title 原标题字段

### DIFF
--- a/WebCrawler/__init__.py
+++ b/WebCrawler/__init__.py
@@ -248,6 +248,7 @@ def get_data_from_json(file_number):  # 从JSON返回元数据
 
     # 返回处理后的json_data
     json_data['title'] = title
+    json_data['original_title'] = title
     json_data['actor'] = actor
     json_data['release'] = release
     json_data['cover_small'] = cover_small


### PR DESCRIPTION
在启用翻译功能后，原标题会被翻译为中文译文，而中文译文的机译质量不稳定。
对于刮削目录的命名规则是原标题，而.nfo元数据的标题字段是机译内容的需求，目前版本还需要两次刮削，第一次配置文件关闭翻译以便生成日文原标题目录，第二次用模式3打开翻译。例如以下配置文件的路径生成规则：
```ini
[Name_Rule]
location_rule='#'+actor+'/'+'['+year+'] '+title+' ['+number+']'

```
本PR新引入的original_title原标题字段可以解决这种问题，在config.ini中使用此字段即可一遍完成以上需求，节省时间和操作步骤。
```ini
[Name_Rule]
location_rule='#'+actor+'/'+'['+year+'] '+original_title+' ['+number+']'

```
