### PR TITLE
describe foloder_path var in a global area to avoid no assign error 

### DIFF
--- a/Movie_Data_Capture.py
+++ b/Movie_Data_Capture.py
@@ -455,6 +455,7 @@ def main():
 
 
     main_mode = conf.main_mode()
+    folder_path = ""
     if not main_mode in (1, 2, 3):
         print(f"[-]Main mode must be 1 or 2 or 3! You can run '{os.path.basename(sys.argv[0])} --help' for more help.")
         sys.exit(4)


### PR DESCRIPTION
```bash
[+]Find movie [SDDE-598] metadata on website 'javbus'
[*]======================================================
Traceback (most recent call last):
  File "/opt/Movie_Data_Capture/Movie_Data_Capture.py", line 585, in <module>
    main()
  File "/opt/Movie_Data_Capture/Movie_Data_Capture.py", line 565, in main
    if len(folder_path):
UnboundLocalError: local variable 'folder_path' referenced before assignment
```