### PR TITLE
修复高宽比大于3/2的图片裁剪

### DIFF
--- a/ImageProcessing/__init__.py
+++ b/ImageProcessing/__init__.py
@@ -1,14 +1,19 @@
 import logging
+import os
 import config
 import importlib
+from PIL import Image
+import shutil
 
-def face_crop(filename, width, height):
+
+def face_crop_width(filename, width, height):
     # 新宽度是高度的2/3
     cropWidthHalf = int(height/3)
     try:
-        locations_model = filter(lambda x: x, config.getInstance().face_locations_model().lower().split(','))
+        locations_model = config.getInstance().face_locations_model().lower().split(',')
+        locations_model = filter(lambda x: x, locations_model)
         for model in locations_model:
-            center = face_center(filename, model)
+            center, top = face_center(filename, model)
             # 如果找到就跳出循环
             if center:
                 cropLeft = center-cropWidthHalf
@@ -27,12 +32,63 @@ def face_crop(filename, width, height):
     return (width-cropWidthHalf*2, 0, width, height)
 
 
+def face_crop_height(filename, width, height):
+    cropHeight = int(width*3/2)
+    try:
+        locations_model = config.getInstance().face_locations_model().lower().split(',')
+        locations_model = filter(lambda x: x, locations_model)
+        for model in locations_model:
+            center, top = face_center(filename, model)
+            # 如果找到就跳出循环
+            if top:
+                # 头部靠上
+                cropTop = top
+                cropBottom = cropHeight + top
+                if cropBottom > height:
+                    cropTop = 0
+                    cropBottom = cropHeight
+                return (0, cropTop, width, cropBottom)
+    except:
+        print('[-]Not found face!   ' + filename)
+    # 默认从顶部向下切割
+    return (0, 0, width, cropHeight)
+
+
+def cutImage(imagecut, path, fanart_path, poster_path):
+    fullpath_fanart = os.path.join(path, fanart_path)
+    fullpath_poster = os.path.join(path, poster_path)
+    if imagecut == 1:  # 剪裁大封面
+        try:
+            img = Image.open(fullpath_fanart)
+            width, height = img.size
+            if width/height > 2/3:  # 如果宽度大于2
+                # 以人像为中心切取
+                img2 = img.crop(face_crop_width(fullpath_fanart, width, height))
+            elif width/height < 2/3:  # 如果高度大于3
+                # 从底部向上切割
+                img2 = img.crop(face_crop_height(fullpath_fanart, width, height))
+            else:  # 如果等于2/3
+                img2 = img
+            img2.save(fullpath_poster)
+            print('[+]Image Cutted!     ' + fullpath_poster)
+        except Exception as e:
+            print(e)
+            print('[-]Cover cut failed!')
+    elif imagecut == 0:  # 复制封面
+        shutil.copyfile(fullpath_fanart, fullpath_poster)
+        print('[+]Image Copyed!     ' + fullpath_poster)
+
+
 def face_center(filename, model):
     print('[+]Use model         ' + model)
     try:
-        mod = importlib.import_module('.' + model,'ImageProcessing')
+        mod = importlib.import_module('.' + model, 'ImageProcessing')
         return mod.face_center(filename, model)
-    except BaseException as e:
+    except Exception as e:
         print('[-]Model found face  ' + filename)
         logging.error(e)
-        return 0
+        return (0, 0)
+
+if __name__ == '__main__':
+    cutImage(1,'H:\\test\\','12.jpg','test.jpg')
+    

--- a/ImageProcessing/baidu.py
+++ b/ImageProcessing/baidu.py
@@ -11,12 +11,15 @@ def face_center(filename, model):
         img = fp.read()
     result = client.bodyAnalysis(img)
     if 'error_code' in result:
-        raise result['error_msg']
+        raise ValueError(result['error_msg'])
     print('[+]Found person      ' + str(result['person_num']))
     # 中心点取鼻子x坐标
-    max = 0
+    maxRight = 0
+    maxTop = 0
     for person_info in result["person_info"]:
         x = int(person_info['body_parts']['nose']['x'])
-        if x > max:
-            max = x
-    return max
+        top = int(person_info['location']['top'])
+        if x > maxRight:
+            maxRight = x
+            maxTop = top
+    return maxRight,maxTop

--- a/ImageProcessing/hog.py
+++ b/ImageProcessing/hog.py
@@ -5,11 +5,13 @@ def face_center(filename, model):
     image = face_recognition.load_image_file(filename)
     face_locations = face_recognition.face_locations(image, 1, model)
     print('[+]Found person      ' + str(len(face_locations)))
-    max = 0
+    maxRight = 0
+    maxTop = 0
     for face_location in face_locations:
         top, right, bottom, left = face_location
         # 中心点
         x = int((right+left)/2)
-        if x > max:
-            max = x
-    return max
+        if x > maxRight:
+            maxRight = x
+            maxTop = top
+    return maxRight,maxTop

--- a/core.py
+++ b/core.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from ADC_function import *
 from WebCrawler import get_data_from_json
 from number_parser import is_uncensored
-from ImageProcessing import face_crop
+from ImageProcessing import cutImage
 
 
 def escape_path(path, escape_literals: str):  # Remove escape literals
@@ -370,31 +370,6 @@ def print_files(path, leak_word, c_word, naming_rule, part, cn_sub, json_data, f
         print("[-]", e1)
         moveFailedFolder(filepath)
         return
-
-def cutImage(imagecut, path, fanart_path, poster_path):
-    fullpath_fanart = os.path.join(path, fanart_path)
-    fullpath_poster = os.path.join(path, poster_path)
-    if imagecut == 1:  # 剪裁大封面
-        try:
-            img = Image.open(fullpath_fanart)
-            width, height = img.size
-            if width/height > 2/3:  # 如果宽度大于2
-                # 以人像为中心切取
-                img2 = img.crop(face_crop(fullpath_fanart, width, height))
-            elif width/height < 2/3:  # 如果高度大于3
-                # 从底部向上切割
-                cropBottom = width*3/2
-                img2 = img.crop(0, 0, width, cropBottom)
-            else:  # 如果等于2/3
-                img2 = img
-            img2.save(fullpath_poster)
-            print('[+]Image Cutted!     ' + fullpath_poster)
-        except Exception as e:
-            print(e)
-            print('[-]Cover cut failed!')
-    elif imagecut == 0:  # 复制封面
-        shutil.copyfile(fullpath_fanart, fullpath_poster)
-        print('[+]Image Copyed!     ' + fullpath_poster)
 
 # 此函数从gui版copy过来用用
 # 参数说明


### PR DESCRIPTION
1. 把图片裁剪移到`ImageProcessing`模块中
2. 修复高宽比大于3/2的图片裁剪参数错误
3. 添加main方法用于测试裁剪正确性