### PR TITLE
JavDB: add User Rating for Emby&Jellyfin

### DIFF
--- a/WebCrawler/javdb.py
+++ b/WebCrawler/javdb.py
@@ -304,6 +304,9 @@ def main(number):
         userrating = getUserRating(lx)
         if userrating:
             dic['userrating'] = userrating
+            dic['rating'] = userrating
+            rating_score = float(userrating) * 20.0
+            dic['criticrating'] = '{:.1f}'.format(rating_score) # 保存小数点后1位即可
         if not dic['actor'] and re.match(r'FC2-[\d]+', number, re.A):
             dic['actor'].append('素人')
             if not dic['series']:

--- a/core.py
+++ b/core.py
@@ -356,6 +356,10 @@ def print_files(path, leak_word, c_word, naming_rule, part, cn_sub, json_data, f
             print("  <release>" + release + "</release>", file=code)
             if 'userrating' in json_data:
                 print("  <userrating>" + json_data['userrating'] + "</userrating>", file=code)
+            if 'rating' in json_data:
+                print("  <rating>" + json_data['rating'] + "</rating>", file=code)
+            if 'criticrating' in json_data:
+                print("  <criticrating>" + json_data['criticrating'] + "</criticrating>", file=code)
             print("  <cover>" + cover + "</cover>", file=code)
             if config.getInstance().is_trailer():
                 print("  <trailer>" + trailer + "</trailer>", file=code)


### PR DESCRIPTION
#737 Solution
由于 #736 中添加的评分标签适用于Kodi而不适用于Emby和Jellyfin
于是在这个PR中新增了两个评分标签
分别是 `<rating> 和 <criticrating>`