### PR TITLE
新功能：完整的多次少量处理功能，增加再次运行延迟

### DIFF
--- a/ADC_function.py
+++ b/ADC_function.py
@@ -381,7 +381,7 @@ def load_cookies(cookie_json_filename: str):
                 break
         if not cookies_filename:
             return None, None
-        return json.load(open(cookies_filename)), cookies_filename
+        return json.loads(Path(cookies_filename).read_text(encoding='utf-8')), cookies_filename
     except:
         return None, None
 
@@ -519,13 +519,12 @@ def download_one_file(args) -> str:
     wrapped for map function
     """
 
-    def _inner(url: str, save_path: Path):
-        filebytes = get_html(url, return_type='content')
-        if isinstance(filebytes, bytes) and len(filebytes):
-            if len(filebytes) == save_path.open('wb').write(filebytes):
+    (url, save_path) = args
+    filebytes = get_html(url, return_type='content')
+    if isinstance(filebytes, bytes) and len(filebytes):
+        with save_path.open('wb') as fpbyte:
+            if len(filebytes) == fpbyte.write(filebytes):
                 return str(save_path)
-
-    return _inner(*args)
 
 
 def parallel_download_files(dn_list: typing.Iterable[typing.Sequence], parallel: int = 0):

--- a/ADC_function.py
+++ b/ADC_function.py
@@ -18,6 +18,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from cloudscraper import create_scraper
 from concurrent.futures import ThreadPoolExecutor
+from unicodedata import category
 
 
 def getXpathSingle(htmlcode, xpath):
@@ -566,6 +567,7 @@ def delete_all_elements_in_list(string: str, lists: typing.Iterable[str]):
             new_lists.append(i)
     return new_lists
 
+
 def delete_all_elements_in_str(string_delete: str, string: str):
     """
     delete same string in given list
@@ -574,3 +576,13 @@ def delete_all_elements_in_str(string_delete: str, string: str):
         if i == string_delete:
             string = string.replace(i,"")
     return string
+
+
+def cnspace(v: str, n: int) -> int:
+    """
+    print format空格填充对齐内容包含中文时的空格计算
+    """
+    cw = 0
+    for c in v:
+        cw += 1 if category(c) in ('Lo',) else 0
+    return n - cw

--- a/ADC_function.py
+++ b/ADC_function.py
@@ -26,7 +26,7 @@ def getXpathSingle(htmlcode, xpath):
     return result1
 
 
-G_USER_AGENT = r'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36'
+G_USER_AGENT = r'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36'
 
 
 def get_html(url, cookies: dict = None, ua: str = None, return_type: str = None, encoding: str = None):

--- a/ImageProcessing/__init__.py
+++ b/ImageProcessing/__init__.py
@@ -55,18 +55,24 @@ def face_crop_height(filename, width, height):
     return (0, 0, width, cropHeight)
 
 
-def cutImage(imagecut, path, fanart_path, poster_path):
+def cutImage(imagecut, path, fanart_path, poster_path, skip_facerec=False):
     fullpath_fanart = os.path.join(path, fanart_path)
     fullpath_poster = os.path.join(path, poster_path)
-    if config.getInstance().download_only_missing_images() and not file_not_exist_or_empty(fullpath_poster):
+    if config.getInstance().face_aways_imagecut():
+        imagecut = 1
+    elif config.getInstance().download_only_missing_images() and not file_not_exist_or_empty(fullpath_poster):
         return
     if imagecut == 1:  # 剪裁大封面
         try:
             img = Image.open(fullpath_fanart)
             width, height = img.size
             if width/height > 2/3:  # 如果宽度大于2
-                # 以人像为中心切取
-                img2 = img.crop(face_crop_width(fullpath_fanart, width, height))
+                if skip_facerec:
+                    # 有码封面默认靠右切
+                    img2 = img.crop((width - int(height/3) * 2, 0, width, height))
+                else:
+                    # 以人像为中心切取
+                    img2 = img.crop(face_crop_width(fullpath_fanart, width, height))
             elif width/height < 2/3:  # 如果高度大于3
                 # 从底部向上切割
                 img2 = img.crop(face_crop_height(fullpath_fanart, width, height))

--- a/ImageProcessing/__init__.py
+++ b/ImageProcessing/__init__.py
@@ -2,6 +2,7 @@ import logging
 import os
 import config
 import importlib
+from pathlib import Path
 from PIL import Image
 import shutil
 from ADC_function import file_not_exist_or_empty
@@ -72,13 +73,13 @@ def cutImage(imagecut, path, fanart_path, poster_path):
             else:  # 如果等于2/3
                 img2 = img
             img2.save(fullpath_poster)
-            print('[+]Image Cutted!     ' + fullpath_poster)
+            print(f"[+]Image Cutted!     {Path(fullpath_poster).name}")
         except Exception as e:
             print(e)
             print('[-]Cover cut failed!')
     elif imagecut == 0:  # 复制封面
         shutil.copyfile(fullpath_fanart, fullpath_poster)
-        print('[+]Image Copyed!     ' + fullpath_poster)
+        print(f"[+]Image Copyed!     {Path(fullpath_poster).name}")
 
 
 def face_center(filename, model):

--- a/ImageProcessing/__init__.py
+++ b/ImageProcessing/__init__.py
@@ -7,6 +7,8 @@ from PIL import Image
 import shutil
 from ADC_function import file_not_exist_or_empty
 
+g_width_half_ratio = 2.12
+
 def face_crop_width(filename, width, height):
     # 新宽度是高度的2/3
     cropWidthHalf = int(height/3)
@@ -22,15 +24,15 @@ def face_crop_width(filename, width, height):
                 # 越界处理
                 if cropLeft < 0:
                     cropLeft = 0
-                    cropRight = cropWidthHalf*2
+                    cropRight = cropWidthHalf*g_width_half_ratio
                 elif cropRight > width:
-                    cropLeft = width-cropWidthHalf*2
+                    cropLeft = width-cropWidthHalf*g_width_half_ratio
                     cropRight = width
                 return (cropLeft, 0, cropRight, height)
     except:
         print('[-]Not found face!   ' + filename)
     # 默认靠右切
-    return (width-cropWidthHalf*2, 0, width, height)
+    return (width-cropWidthHalf * g_width_half_ratio, 0, width, height)
 
 
 def face_crop_height(filename, width, height):
@@ -69,7 +71,7 @@ def cutImage(imagecut, path, fanart_path, poster_path, skip_facerec=False):
             if width/height > 2/3:  # 如果宽度大于2
                 if skip_facerec:
                     # 有码封面默认靠右切
-                    img2 = img.crop((width - int(height/3) * 2, 0, width, height))
+                    img2 = img.crop((width - int(height/3) * g_width_half_ratio, 0, width, height))
                 else:
                     # 以人像为中心切取
                     img2 = img.crop(face_crop_width(fullpath_fanart, width, height))

--- a/ImageProcessing/__init__.py
+++ b/ImageProcessing/__init__.py
@@ -7,9 +7,9 @@ from PIL import Image
 import shutil
 from ADC_function import file_not_exist_or_empty
 
-g_width_half_ratio = 2.12
 
 def face_crop_width(filename, width, height):
+    aspect_ratio = config.getInstance().face_aspect_ratio()
     # 新宽度是高度的2/3
     cropWidthHalf = int(height/3)
     try:
@@ -24,15 +24,15 @@ def face_crop_width(filename, width, height):
                 # 越界处理
                 if cropLeft < 0:
                     cropLeft = 0
-                    cropRight = cropWidthHalf*g_width_half_ratio
+                    cropRight = cropWidthHalf * aspect_ratio
                 elif cropRight > width:
-                    cropLeft = width-cropWidthHalf*g_width_half_ratio
+                    cropLeft = width - cropWidthHalf * aspect_ratio
                     cropRight = width
                 return (cropLeft, 0, cropRight, height)
     except:
         print('[-]Not found face!   ' + filename)
     # 默认靠右切
-    return (width-cropWidthHalf * g_width_half_ratio, 0, width, height)
+    return (width-cropWidthHalf * aspect_ratio, 0, width, height)
 
 
 def face_crop_height(filename, width, height):
@@ -58,11 +58,13 @@ def face_crop_height(filename, width, height):
 
 
 def cutImage(imagecut, path, fanart_path, poster_path, skip_facerec=False):
+    conf = config.getInstance()
     fullpath_fanart = os.path.join(path, fanart_path)
     fullpath_poster = os.path.join(path, poster_path)
-    if config.getInstance().face_aways_imagecut():
+    aspect_ratio = conf.face_aspect_ratio()
+    if conf.face_aways_imagecut():
         imagecut = 1
-    elif config.getInstance().download_only_missing_images() and not file_not_exist_or_empty(fullpath_poster):
+    elif conf.download_only_missing_images() and not file_not_exist_or_empty(fullpath_poster):
         return
     if imagecut == 1:  # 剪裁大封面
         try:
@@ -71,7 +73,7 @@ def cutImage(imagecut, path, fanart_path, poster_path, skip_facerec=False):
             if width/height > 2/3:  # 如果宽度大于2
                 if skip_facerec:
                     # 有码封面默认靠右切
-                    img2 = img.crop((width - int(height/3) * g_width_half_ratio, 0, width, height))
+                    img2 = img.crop((width - int(height/3) * aspect_ratio, 0, width, height))
                 else:
                     # 以人像为中心切取
                     img2 = img.crop(face_crop_width(fullpath_fanart, width, height))

--- a/Movie_Data_Capture.py
+++ b/Movie_Data_Capture.py
@@ -365,7 +365,7 @@ def movie_lists(source_folder, regexstr: str) -> typing.List[str]:
     skip_numbers = set()
     success_folder = Path(conf.success_folder()).resolve()
     for f in success_folder.glob(r'**/*'):
-        if not re.match(r'\.nfo', f.suffix, re.IGNORECASE):
+        if not re.match(r'\.nfo$', f.suffix, re.IGNORECASE):
             continue
         if file_modification_days(f) > nfo_skip_days:
             continue

--- a/Movie_Data_Capture.py
+++ b/Movie_Data_Capture.py
@@ -655,10 +655,10 @@ if __name__ == '__main__':
                     剩余个数 = 扫描电影数 - 已处理
                     总用时 = timedelta(seconds = time.time() - app_start)
                     print(f'All movies:{扫描电影数}  processed:{已处理}  successes:{完成数}  remain:{剩余个数}' +
-                        '  total time:{}'.format(
-                        period(总用时, "{d} day {h:02}:{m:02}:{s:02}") if 总用时.days == 1
-                            else period(总用时, "{d} days {h:02}:{m:02}:{s:02}") if 总用时.days > 1
-                            else period(总用时, "{h:02}:{m:02}:{s:02}")))
+                        '  Elapsed time {}'.format(
+                        period(总用时, "{d} day {h}:{m:02}:{s:02}") if 总用时.days == 1
+                            else period(总用时, "{d} days {h}:{m:02}:{s:02}") if 总用时.days > 1
+                            else period(总用时, "{h}:{m:02}:{s:02}")))
                     if 剩余个数 == 0:
                         break
                     下次运行 = datetime.now() + timedelta(seconds=再运行延迟)

--- a/Movie_Data_Capture.py
+++ b/Movie_Data_Capture.py
@@ -101,9 +101,10 @@ is performed. It may help you correct wrong numbers before real job.""")
     no_net_op = False
     if conf.main_mode() == 3:
         no_net_op = args.no_network_operation
-        config.G_conf_override["common:stop_counter"] = 0
-        config.G_conf_override["common:rerun_delay"] = '0s'
-        config.G_conf_override["face:aways_imagecut"] = True
+        if no_net_op:
+            config.G_conf_override["common:stop_counter"] = 0
+            config.G_conf_override["common:rerun_delay"] = '0s'
+            config.G_conf_override["face:aways_imagecut"] = True
 
     return args.file, args.number, args.logdir, args.regexstr, args.zero_op, no_net_op
 

--- a/Movie_Data_Capture.py
+++ b/Movie_Data_Capture.py
@@ -626,10 +626,18 @@ def 分析日志文件(logfile):
         return None, None, None
 
 
+def period(delta, pattern):
+    d = {'d': delta.days}
+    d['h'], rem = divmod(delta.seconds, 3600)
+    d['m'], d['s'] = divmod(rem, 60)
+    return pattern.format(**d)
+
+
 if __name__ == '__main__':
     version = '6.0.3'
     multiprocessing.freeze_support()
     urllib3.disable_warnings()  # Ignore http proxy warning
+    app_start = time.time()
 
     # Read config.ini first, in argparse_function() need conf.failed_folder()
     conf = config.Config("config.ini")
@@ -645,7 +653,12 @@ if __name__ == '__main__':
                 (扫描电影数, 已处理, 完成数) = 分析结果元组 = tuple(分析日志文件(logfile))
                 if all(isinstance(v, int) for v in 分析结果元组):
                     剩余个数 = 扫描电影数 - 已处理
-                    print(f'All movies:{扫描电影数}  processed:{已处理}  successes:{完成数}  remain:{剩余个数}')
+                    总用时 = timedelta(seconds = time.time() - app_start)
+                    print(f'All movies:{扫描电影数}  processed:{已处理}  successes:{完成数}  remain:{剩余个数}' +
+                        '  total time:{}'.format(
+                        period(总用时, "{d} day {h:02}:{m:02}:{s:02}") if 总用时.days == 1
+                            else period(总用时, "{d} days {h:02}:{m:02}:{s:02}") if 总用时.days > 1
+                            else period(总用时, "{h:02}:{m:02}:{s:02}")))
                     if 剩余个数 == 0:
                         break
                     下次运行 = datetime.now() + timedelta(seconds=再运行延迟)

--- a/WebCrawler/__init__.py
+++ b/WebCrawler/__init__.py
@@ -248,8 +248,8 @@ def get_data_from_json(file_number, oCC):
             if json_data[translate_value] == "":
                 continue
             if translate_value == "title":
-                title_dict = json.load(
-                    open(str(Path.home() / '.local' / 'share' / 'mdc' / 'c_number.json'), 'r', encoding="utf-8"))
+                title_dict = json.loads(
+                    (Path.home() / '.local' / 'share' / 'mdc' / 'c_number.json').read_text(encoding="utf-8"))
                 try:
                     json_data[translate_value] = title_dict[number]
                     continue

--- a/WebCrawler/carib.py
+++ b/WebCrawler/carib.py
@@ -40,6 +40,7 @@ def main(number: str) -> json:
             'website': f'{G_SITE}/moviepages/{number}/index.html',
             'source': 'carib.py',
             'series': get_series(lx),
+            '无码': True
         }
         js = json.dumps(dic, ensure_ascii=False, sort_keys=True, indent=4, separators=(',', ':'), )
         return js

--- a/WebCrawler/fanza.py
+++ b/WebCrawler/fanza.py
@@ -250,6 +250,9 @@ def main(number):
         # but the hinban on the page is test00012
         # so get the hinban first, and then pass it to following functions
         fanza_hinban = getNum(htmlcode)
+        out_num = fanza_hinban
+        if re.sub('-|_', '', number.lower()) == fanza_hinban:
+            out_num = number
         data = {
             "title": getTitle(htmlcode).strip(),
             "studio": getStudio(htmlcode),
@@ -258,7 +261,7 @@ def main(number):
             "director": getDirector(htmlcode) if "anime" not in chosen_url else "",
             "actor": getActor(htmlcode) if "anime" not in chosen_url else "",
             "release": getRelease(htmlcode),
-            "number": fanza_hinban,
+            "number": out_num,
             "cover": getCover(htmlcode, fanza_hinban),
             "imagecut": 1,
             "tag": getTag(htmlcode),
@@ -315,3 +318,5 @@ if __name__ == "__main__":
     # print(main("DV-1562"))
     # print(main("96fad1217"))
     print(main("pred00251"))
+    print(main("MIAA-391"))
+    print(main("OBA-326"))

--- a/WebCrawler/fanza.py
+++ b/WebCrawler/fanza.py
@@ -252,7 +252,10 @@ def main(number):
         fanza_hinban = getNum(htmlcode)
         out_num = fanza_hinban
         number_lo = number.lower()
-        if re.sub('-|_', '', number_lo) == fanza_hinban or number_lo.replace('-', '00') == fanza_hinban:
+        if (re.sub('-|_', '', number_lo) == fanza_hinban or
+            number_lo.replace('-', '00') == fanza_hinban or
+            number_lo.replace('-', '') + 'so' == fanza_hinban
+        ):
             out_num = number
         data = {
             "title": getTitle(htmlcode).strip(),

--- a/WebCrawler/fanza.py
+++ b/WebCrawler/fanza.py
@@ -251,7 +251,8 @@ def main(number):
         # so get the hinban first, and then pass it to following functions
         fanza_hinban = getNum(htmlcode)
         out_num = fanza_hinban
-        if re.sub('-|_', '', number.lower()) == fanza_hinban:
+        number_lo = number.lower()
+        if re.sub('-|_', '', number_lo) == fanza_hinban or number_lo.replace('-', '00') == fanza_hinban:
             out_num = number
         data = {
             "title": getTitle(htmlcode).strip(),

--- a/WebCrawler/javbus.py
+++ b/WebCrawler/javbus.py
@@ -88,7 +88,8 @@ def getUncensored(html):
     return bool(x)
 
 def main_uncensored(number):
-    htmlcode = get_html('https://www.javbus.com/ja/' + number)
+    w_number = number.replace('.', '-')
+    htmlcode = get_html('https://www.javbus.red/' + w_number)
     if "<title>404 Page Not Found" in htmlcode:
         raise Exception('404 page not found')
     lx = etree.fromstring(htmlcode, etree.HTMLParser())
@@ -97,7 +98,7 @@ def main_uncensored(number):
         'title': title,
         'studio': getStudioJa(lx),
         'year': getYear(lx),
-        'outline': getOutline(number, title),
+        'outline': getOutline(w_number, title),
         'runtime': getRuntime(lx),
         'director': getDirectorJa(lx),
         'actor': getActor(lx),
@@ -109,10 +110,10 @@ def main_uncensored(number):
         'label': getSeriseJa(lx),
         'imagecut': 0,
 #        'actor_photo': '',
-        'website': 'https://www.javbus.com/ja/' + number,
+        'website': 'https://www.javbus.red/' + w_number,
         'source': 'javbus.py',
         'series': getSeriseJa(lx),
-        '无码': getUncensored(lx)
+        '无码': True
     }
     js = json.dumps(dic, ensure_ascii=False, sort_keys=True, indent=4, separators=(',', ':'), )  # .encode('UTF-8')
     return js
@@ -174,12 +175,13 @@ def main(number):
 
 if __name__ == "__main__" :
     config.G_conf_override['debug_mode:switch'] = True
-    print(main('ABP-888'))
-    print(main('ABP-960'))
-    print(main('ADV-R0624'))    # 404
-    print(main('MMNT-010'))
-    print(main('ipx-292'))
-    print(main('CEMD-011'))
-    print(main('CJOD-278'))
+    # print(main('ABP-888'))
+    # print(main('ABP-960'))
+    # print(main('ADV-R0624'))    # 404
+    # print(main('MMNT-010'))
+    # print(main('ipx-292'))
+    # print(main('CEMD-011'))
+    # print(main('CJOD-278'))
+    print(main('BrazzersExxtra.21.02.01'))
     print(main('100221_001'))
     print(main('AVSW-061'))

--- a/WebCrawler/javbus.py
+++ b/WebCrawler/javbus.py
@@ -83,6 +83,9 @@ def getExtrafanart(htmlcode):  # 获取剧照
         if extrafanart_imgs:
             return [urljoin('https://www.javbus.com',img) for img in extrafanart_imgs]
     return ''
+def getUncensored(html):
+    x = html.xpath('//*[@id="navbar"]/ul[1]/li[@class="active"]/a[contains(@href,"uncensored")]')
+    return bool(x)
 
 def main_uncensored(number):
     htmlcode = get_html('https://www.javbus.com/ja/' + number)
@@ -109,6 +112,7 @@ def main_uncensored(number):
         'website': 'https://www.javbus.com/ja/' + number,
         'source': 'javbus.py',
         'series': getSeriseJa(lx),
+        '无码': getUncensored(lx)
     }
     js = json.dumps(dic, ensure_ascii=False, sort_keys=True, indent=4, separators=(',', ':'), )  # .encode('UTF-8')
     return js
@@ -151,6 +155,7 @@ def main(number):
                 'website': 'https://www.javbus.com/' + number,
                 'source': 'javbus.py',
                 'series': getSerise(lx),
+                '无码': getUncensored(lx)
             }
             js = json.dumps(dic, ensure_ascii=False, sort_keys=True, indent=4,separators=(',', ':'), )  # .encode('UTF-8')
             return js

--- a/WebCrawler/javdb.py
+++ b/WebCrawler/javdb.py
@@ -179,6 +179,9 @@ def getUserRating(html):
         return float(v[0][0]), int(v[0][1])
     except:
         return
+def getUncensored(html):
+    x = html.xpath('//strong[contains(text(),"類別")]/../span/a[contains(@href,"/tags/uncensored?")]')
+    return bool(x)
 
 def main(number):
     # javdb更新后同一时间只能登录一个数字站，最新登录站会踢出旧的登录，因此按找到的第一个javdb*.json文件选择站点，
@@ -300,7 +303,7 @@ def main(number):
             'website': urljoin('https://javdb.com', correct_url),
             'source': 'javdb.py',
             'series': getSeries(lx),
-
+            '无码': getUncensored(lx)
         }
         userrating = getUserRating(lx)
         if isinstance(userrating, tuple) and len(userrating) == 2:
@@ -328,7 +331,7 @@ if __name__ == "__main__":
     # print(main('blacked.20.05.30'))
     # print(main('AGAV-042'))
     # print(main('BANK-022'))
-    # print(main('070116-197'))
+    print(main('070116-197'))
     # print(main('093021_539'))  # 没有剧照 片商pacopacomama
     #print(main('FC2-2278260'))
     # print(main('FC2-735670'))

--- a/WebCrawler/javdb.py
+++ b/WebCrawler/javdb.py
@@ -180,7 +180,8 @@ def getUserRating(html):
     except:
         return
 def getUncensored(html):
-    x = html.xpath('//strong[contains(text(),"類別")]/../span/a[contains(@href,"/tags/uncensored?")]')
+    x = html.xpath('//strong[contains(text(),"類別")]/../span/a[contains(@href,"/tags/uncensored?")'
+                ' or contains(@href,"/tags/western?")]')
     return bool(x)
 
 def main(number):
@@ -342,3 +343,4 @@ if __name__ == "__main__":
     # print(main('EBOD-646'))
     # print(main('LOVE-262'))
     print(main('ABP-890'))
+    print(main('blacked.14.12.08'))

--- a/WebCrawler/madou.py
+++ b/WebCrawler/madou.py
@@ -146,7 +146,8 @@ def main(number):
             'website': url,
             'source': 'madou.py',
             # 使用
-            'series': getSerise(html)
+            'series': getSerise(html),
+            '无码': True
         }
         js = json.dumps(dic, ensure_ascii=False, sort_keys=True,
                         indent=4, separators=(',', ':'), )  # .encode('UTF-8')

--- a/WebCrawler/storyline.py
+++ b/WebCrawler/storyline.py
@@ -308,8 +308,8 @@ def getStoryline_amazon(q_title, number, debug):
             res = session.get(urljoin(res.url, lks[0]))
             cookie = None
             lx = fromstring(res.text)
-        titles = lx.xpath("//span[contains(@class,'a-color-base a-text-normal')]/text()")
-        urls = lx.xpath("//span[contains(@class,'a-color-base a-text-normal')]/../@href")
+        titles = lx.xpath("//span[contains(@class,'a-size-base-plus a-color-base a-text-normal')]/text()")
+        urls = lx.xpath("//span[contains(@class,'a-size-base-plus a-color-base a-text-normal')]/../@href")
         if not len(urls) or len(urls) != len(titles):
             raise ValueError("titles not found")
         idx = amazon_select_one(titles, q_title, number, debug)
@@ -325,8 +325,9 @@ def getStoryline_amazon(q_title, number, debug):
             res = session.get(urljoin(res.url, lks[0]))
             cookie = None
             lx = fromstring(res.text)
-        div = lx.xpath('//*[@id="productDescription"]')[0]
-        ama_t = ' '.join([e.text.strip() for e in div if not re.search('Comment|h3', str(e.tag), re.I) and isinstance(e.text, str)])
+        p1 = lx.xpath('//*[@id="productDescription"]/p[1]/span/text()')
+        p2 = lx.xpath('//*[@id="productDescription"]/p[2]/span/text()')
+        ama_t = ' '.join(p1) + ' '.join(p2)
         ama_t = re.sub(r'審査番号:\d+', '', ama_t).strip()
 
         if cookie is None:
@@ -406,10 +407,10 @@ def amazon_select_one(a_titles, q_title, number, debug):
     # debug 模式下记录识别准确率日志
     if ratio < 0.9:
         # 相似度[0.5, 0.9)的淘汰结果单独记录日志
-        (Path.home() / '.avlogs/ratio0.5.txt').open('a', encoding='utf-8').write(
-            f' [{number}]  Ratio:{ratio}\n{a_titles[sel]}\n{q_title}\n{save_t_}\n{que_t}\n')
+        with (Path.home() / '.mlogs/ratio0.5.txt').open('a', encoding='utf-8') as hrt:
+            hrt.write(f' [{number}]  Ratio:{ratio}\n{a_titles[sel]}\n{q_title}\n{save_t_}\n{que_t}\n')
         return -1
     # 被采信的结果日志
-    (Path.home() / '.avlogs/ratio.txt').open('a', encoding='utf-8').write(
-        f' [{number}]  Ratio:{ratio}\n{a_titles[sel]}\n{q_title}\n{save_t_}\n{que_t}\n')
+    with (Path.home() / '.mlogs/ratio.txt').open('a', encoding='utf-8') as hrt:
+        hrt.write(f' [{number}]  Ratio:{ratio}\n{a_titles[sel]}\n{q_title}\n{save_t_}\n{que_t}\n')
     return sel

--- a/WebCrawler/storyline.py
+++ b/WebCrawler/storyline.py
@@ -80,34 +80,34 @@ def getStoryline(number, title, sites: list=None):
 
 
 def getStoryline_mp(args):
-    def _inner(site, number, title, debug):
-        start_time = time.time()
-        storyline = None
-        if not isinstance(site, str):
-            return storyline
-        elif site == "airavwiki":
-            storyline = getStoryline_airavwiki(number, debug)
-        elif site == "airav":
-            storyline = getStoryline_airav(number, debug)
-        elif site == "avno1":
-            storyline = getStoryline_avno1(number, debug)
-        elif site == "xcity":
-            storyline = getStoryline_xcity(number, debug)
-        elif site == "amazon":
-            storyline = getStoryline_amazon(title, number, debug)
-        elif site == "58avgo":
-            storyline = getStoryline_58avgo(number, debug)
-        if not debug:
-            return storyline
-        # 进程池模式的子进程getStoryline_*()的print()不会写入日志中，线程池和顺序执行不受影响
-        print("[!]MP 进程[{}]运行{:.3f}秒，结束于{}返回结果: {}".format(
-                site,
-                time.time() - start_time,
-                time.strftime("%H:%M:%S"),
-                storyline if isinstance(storyline, str) and len(storyline) else '[空]')
-        )
+    (site, number, title, debug) = args
+    start_time = time.time()
+    storyline = None
+    if not isinstance(site, str):
         return storyline
-    return _inner(*args)
+    elif site == "airavwiki":
+        storyline = getStoryline_airavwiki(number, debug)
+        #storyline = getStoryline_airavwiki_super(number, debug)
+    elif site == "airav":
+        storyline = getStoryline_airav(number, debug)
+    elif site == "avno1":
+        storyline = getStoryline_avno1(number, debug)
+    elif site == "xcity":
+        storyline = getStoryline_xcity(number, debug)
+    elif site == "amazon":
+        storyline = getStoryline_amazon(title, number, debug)
+    elif site == "58avgo":
+        storyline = getStoryline_58avgo(number, debug)
+    if not debug:
+        return storyline
+    # 进程池模式的子进程getStoryline_*()的print()不会写入日志中，线程池和顺序执行不受影响
+    print("[!]MP 进程[{}]运行{:.3f}秒，结束于{}返回结果: {}".format(
+            site,
+            time.time() - start_time,
+            time.strftime("%H:%M:%S"),
+            storyline if isinstance(storyline, str) and len(storyline) else '[空]')
+    )
+    return storyline
 
 
 def getStoryline_airav(number, debug):

--- a/config.ini
+++ b/config.ini
@@ -122,7 +122,9 @@ sites=38,39
 ; 人脸识别 locations_model=hog:方向梯度直方图(不太准确，速度快) cnn:深度学习模型(准确，需要GPU/CUDA,速度慢)
 ; uncensored_only=0:对全部封面进行人脸识别 1:只识别无码封面，有码封面直接切右半部分
 ; aways_imagecut=0:按各网站默认行为 1:总是裁剪封面，开启此项将无视[common]download_only_missing_images=1总是覆盖封面
+; 封面裁剪的宽高比可配置，公式为aspect_ratio/3。默认aspect_ratio=2.12: 适配大部分有码影片封面，前一版本默认为2/3即aspect_ratio=2
 [face]
 locations_model=hog
 uncensored_only=1
 aways_imagecut=0
+aspect_ratio=2.12

--- a/config.ini
+++ b/config.ini
@@ -119,6 +119,10 @@ vars=outline,series,studio,tag,title
 [javdb]
 sites=38,39
 
-; 人脸识别 hog:方向梯度直方图(不太准确，速度快) cnn:深度学习模型(准确，需要GPU/CUDA,速度慢)
+; 人脸识别 locations_model=hog:方向梯度直方图(不太准确，速度快) cnn:深度学习模型(准确，需要GPU/CUDA,速度慢)
+; uncensored_only=0:对全部封面进行人脸识别 1:只识别无码封面，有码封面直接切右半部分
+; aways_imagecut=0:按各网站默认行为 1:总是裁剪封面，开启此项将无视[common]download_only_missing_images=1总是覆盖封面
 [face]
 locations_model=hog
+uncensored_only=1
+aways_imagecut=0

--- a/config.ini
+++ b/config.ini
@@ -117,7 +117,7 @@ mode=1
 vars=outline,series,studio,tag,title
 
 [javdb]
-sites=37,38
+sites=38,39
 
 ; 人脸识别 hog:方向梯度直方图(不太准确，速度快) cnn:深度学习模型(准确，需要GPU/CUDA,速度慢)
 [face]

--- a/config.ini
+++ b/config.ini
@@ -79,7 +79,7 @@ uncensored_prefix=S2M,BT,LAF,SMD,SMBD,SM3D2DBD,SKY-,SKYHD,CWP,CWDV,CWBD,CW3D2DBD
 ; 影片后缀
 media_type=.mp4,.avi,.rmvb,.wmv,.mov,.mkv,.flv,.ts,.webm,.iso,.mpg,.m4v
 ; 字幕后缀
-sub_type=.smi,.srt,.idx,.sub,.sup,.psb,.ssa,.ass,.txt,.usf,.xss,.ssf,.rt,.lrc,.sbv,.vtt,.ttml
+sub_type=.smi,.srt,.idx,.sub,.sup,.psb,.ssa,.ass,.usf,.xss,.ssf,.rt,.lrc,.sbv,.vtt,.ttml
 
 ; 水印
 [watermark]

--- a/config.ini
+++ b/config.ini
@@ -20,7 +20,10 @@ del_empty_folder=1
 nfo_skip_days=30
 ; 处理完多少个视频文件后停止，0为处理所有视频文件
 stop_counter=0
-; 以上两个参数配合使用可以以多次少量的方式刮削或整理数千个文件而不触发翻译或元数据站封禁
+; 再运行延迟时间，单位：h时m分s秒 举例: 1h30m45s(1小时30分45秒)  45(45秒)
+; stop_counter不为零的条件下才有效，每处理stop_counter部影片后延迟rerun_delay秒再次运行
+rerun_delay=0
+; 以上三个参数配合使用可以以多次少量的方式刮削或整理数千个文件而不触发翻译或元数据站封禁
 ignore_failed_list=0
 download_only_missing_images=1
 mapping_table_validity=7

--- a/config.py
+++ b/config.py
@@ -365,6 +365,9 @@ class Config:
     def face_aways_imagecut(self) -> bool:
         return self.getboolean_override("face", "aways_imagecut", fallback=False)
 
+    def face_aspect_ratio(self) -> float:
+        return self.conf.getfloat("face", "aspect_ratio", fallback=2.12)
+
     @staticmethod
     def _exit(sec: str) -> None:
         print("[-] Read config error! Please check the {} section in config.ini", sec)

--- a/config.py
+++ b/config.py
@@ -18,7 +18,8 @@ G_conf_override = {
     "common:stop_counter": None,
     "common:ignore_failed_list": None,
     "common:rerun_delay": None,
-    "debug_mode:switch": None
+    "debug_mode:switch": None,
+    "face:aways_imagecut": None
 }
 
 
@@ -101,9 +102,12 @@ class Config:
             #     sys.exit(3)
             #     #self.conf = self._default_config()
 
-    def getboolean_override(self, section, item) -> bool:
-        return self.conf.getboolean(section, item) if G_conf_override[f"{section}:{item}"] is None else bool(
-            G_conf_override[f"{section}:{item}"])
+    def getboolean_override(self, section, item, fallback=None) -> bool:
+        if G_conf_override[f"{section}:{item}"] is not None:
+            return bool(G_conf_override[f"{section}:{item}"])
+        if fallback is not None:
+            return self.conf.getboolean(section, item, fallback=fallback)
+        return self.conf.getboolean(section, item)
 
     def getint_override(self, section, item, fallback=None) -> int:
         if G_conf_override[f"{section}:{item}"] is not None:
@@ -359,7 +363,7 @@ class Config:
         return self.conf.getboolean("face", "uncensored_only", fallback=True)
 
     def face_aways_imagecut(self) -> bool:
-        return self.conf.getboolean("face", "aways_imagecut", fallback=False)
+        return self.getboolean_override("face", "aways_imagecut", fallback=False)
 
     @staticmethod
     def _exit(sec: str) -> None:

--- a/config.py
+++ b/config.py
@@ -3,6 +3,7 @@ import re
 import sys
 import configparser
 import time
+import typing
 from pathlib import Path
 
 G_conf_override = {
@@ -263,8 +264,8 @@ class Config:
     def media_type(self) -> str:
         return self.conf.get('media', 'media_type')
 
-    def sub_rule(self):
-        return self.conf.get('media', 'sub_type').split(',')
+    def sub_rule(self) -> typing.Set[str]:
+        return set(self.conf.get('media', 'sub_type').lower().split(','))
 
     def naming_rule(self) -> str:
         return self.conf.get("Name_Rule", "naming_rule")
@@ -445,9 +446,9 @@ class Config:
         sec11 = "media"
         conf.add_section(sec11)
         conf.set(sec11, "media_type",
-                 ".mp4,.avi,.rmvb,.wmv,.mov,.mkv,.flv,.ts,.webm,.MP4,.AVI,.RMVB,.WMV,.MOV,.MKV,.FLV,.TS,.WEBM,iso,ISO")
+                 ".mp4,.avi,.rmvb,.wmv,.mov,.mkv,.flv,.ts,.webm,iso")
         conf.set(sec11, "sub_type",
-                 ".smi,.srt,.idx,.sub,.sup,.psb,.ssa,.ass,.txt,.usf,.xss,.ssf,.rt,.lrc,.sbv,.vtt,.ttml")
+                 ".smi,.srt,.idx,.sub,.sup,.psb,.ssa,.ass,.usf,.xss,.ssf,.rt,.lrc,.sbv,.vtt,.ttml")
 
         sec12 = "watermark"
         conf.add_section(sec12)

--- a/config.py
+++ b/config.py
@@ -346,22 +346,20 @@ class Config:
             return 1
 
     def cc_convert_vars(self) -> str:
-        try:
-            return self.conf.get("cc_convert", "vars")
-        except:
-            return "actor,director,label,outline,series,studio,tag,title"
+        return self.conf.get("cc_convert", "vars",
+            fallback="actor,director,label,outline,series,studio,tag,title")
 
     def javdb_sites(self) -> str:
-        try:
-            return self.conf.get("javdb", "sites")
-        except:
-            return "33,34"
+        return self.conf.get("javdb", "sites", fallback="38,39")
 
     def face_locations_model(self) -> str:
-        try:
-            return self.conf.get("face", "locations_model")
-        except:
-            return "hog"
+        return self.conf.get("face", "locations_model", fallback="hog")
+
+    def face_uncensored_only(self) -> bool:
+        return self.conf.getboolean("face", "uncensored_only", fallback=True)
+
+    def face_aways_imagecut(self) -> bool:
+        return self.conf.getboolean("face", "aways_imagecut", fallback=False)
 
     @staticmethod
     def _exit(sec: str) -> None:

--- a/core.py
+++ b/core.py
@@ -617,6 +617,7 @@ def debug_print(data: json):
 
 def core_main_no_net_op(movie_path, number):
     conf = config.getInstance()
+    part = ''
     leak_word = ''
     leak = 0
     c_word = ''
@@ -627,6 +628,8 @@ def core_main_no_net_op(movie_path, number):
     imagecut = 1
     path = str(Path(movie_path).parent)
 
+    if re.search('-CD\d+', movie_path, re.IGNORECASE):
+        part = re.findall('-CD\d+', movie_path, re.IGNORECASE)[0]
     if '-c.' in movie_path or '-C.' in movie_path or '中文' in movie_path or '字幕' in movie_path:
         cn_sub = '1'
         c_word = '-C'  # 中文字幕影片后缀
@@ -639,12 +642,19 @@ def core_main_no_net_op(movie_path, number):
         hack = 1
         hack_word = "-hack"
 
-    fanart_path =  f"{number}{leak_word}{c_word}{hack_word}-fanart{ext}"
-    poster_path = f"{number}{leak_word}{c_word}{hack_word}-poster{ext}"
-    thumb_path =  f"{number}{leak_word}{c_word}{hack_word}-thumb{ext}"
+    prestr = f"{number}{leak_word}{c_word}{hack_word}"
+    fanart_path =  f"{prestr}-fanart{ext}"
+    poster_path = f"{prestr}-poster{ext}"
+    thumb_path =  f"{prestr}-thumb{ext}"
     full_fanart_path = os.path.join(path, fanart_path)
     full_poster_path = os.path.join(path, poster_path)
     full_thumb_path = os.path.join(path, thumb_path)
+    full_nfo = Path(path) / f"{prestr}{part}.nfo"
+
+    if full_nfo.is_file():
+        nfo = full_nfo.read_text(encoding='utf-8')
+        if nfo.find(r'<tag>无码</tag>'):
+            uncensored = 1
 
     if not all(os.path.isfile(f) for f in (full_fanart_path, full_thumb_path)):
         return
@@ -695,7 +705,8 @@ def core_main(movie_path, number_th, oCC):
 
     # 判断是否无码
     uncensored = 1 if is_uncensored(number) else 0
-
+    if json_data.get('无码'):
+        uncensored = 1
 
     if '流出' in movie_path or 'uncensored' in movie_path:
         liuchu = '流出'

--- a/core.py
+++ b/core.py
@@ -655,6 +655,8 @@ def core_main_no_net_op(movie_path, number):
         nfo = full_nfo.read_text(encoding='utf-8')
         if nfo.find(r'<tag>无码</tag>'):
             uncensored = 1
+    else:
+        return
 
     if not all(os.path.isfile(f) for f in (full_fanart_path, full_thumb_path)):
         return

--- a/core.py
+++ b/core.py
@@ -70,10 +70,12 @@ def get_info(json_data):  # 返回json里的数据
     return title, studio, year, outline, runtime, director, actor_photo, release, number, cover, trailer, website, series, label
 
 
-def small_cover_check(path, number, cover_small, leak_word, c_word, hack_word, filepath):
-    filename = f"{number}{leak_word}{c_word}{hack_word}-poster.jpg"
-    download_file_with_filename(cover_small, filename, path, filepath)
-    print('[+]Image Downloaded! ' + os.path.join(path, filename))
+def small_cover_check(path, filename, cover_small, movie_path):
+    full_filepath = os.path.join(path, filename)
+    if config.getInstance().download_only_missing_images() and not file_not_exist_or_empty(full_filepath):
+        return
+    download_file_with_filename(cover_small, filename, path, movie_path)
+    print('[+]Image Downloaded! ' + full_filepath)
 
 
 def create_folder(json_data):  # 创建文件夹
@@ -256,7 +258,7 @@ def image_ext(url):
         return ".jpg"
 
 # 封面是否下载成功，否则移动到failed
-def image_download(cover, fanart_path,thumb_path, path, filepath):
+def image_download(cover, fanart_path, thumb_path, path, filepath):
     full_filepath = os.path.join(path, fanart_path)
     if config.getInstance().download_only_missing_images() and not file_not_exist_or_empty(full_filepath):
         return
@@ -696,8 +698,7 @@ def core_main(file_path, number_th, oCC):
 
         # 检查小封面, 如果image cut为3，则下载小封面
         if imagecut == 3:
-            small_cover_check(path, number,  json_data.get('cover_small'), leak_word, c_word, hack_word, filepath)
-
+            small_cover_check(path, poster_path, json_data.get('cover_small'), filepath)
 
         # creatFolder会返回番号路径
         image_download( cover, fanart_path,thumb_path, path, filepath)
@@ -718,7 +719,7 @@ def core_main(file_path, number_th, oCC):
 
 
         # 裁剪图
-        cutImage(imagecut, path , fanart_path, poster_path)
+        cutImage(imagecut, path, fanart_path, poster_path)
 
         # 添加水印
         if conf.is_watermark():
@@ -746,7 +747,7 @@ def core_main(file_path, number_th, oCC):
 
         # 检查小封面, 如果image cut为3，则下载小封面
         if imagecut == 3:
-            small_cover_check(path, number, json_data.get('cover_small'), leak_word, c_word, hack_word, filepath)
+            small_cover_check(path, poster_path, json_data.get('cover_small'), filepath)
 
         # creatFolder会返回番号路径
         image_download( cover, fanart_path,thumb_path, path, filepath)
@@ -761,7 +762,7 @@ def core_main(file_path, number_th, oCC):
                 extrafanart_download(json_data.get('extrafanart'), path, number, filepath)
 
         # 裁剪图
-        cutImage(imagecut, path , fanart_path, poster_path)
+        cutImage(imagecut, path, fanart_path, poster_path)
 
         # 添加水印
         if conf.is_watermark():

--- a/core.py
+++ b/core.py
@@ -717,7 +717,7 @@ def core_main(file_path, number_th, oCC):
 
 
         # 裁剪图
-        cutImage(imagecut, path, fanart_path, poster_path)
+        cutImage(imagecut, path, fanart_path, poster_path, bool(conf.face_uncensored_only() and not uncensored))
 
         # 添加水印
         if conf.is_watermark():
@@ -760,7 +760,7 @@ def core_main(file_path, number_th, oCC):
                 extrafanart_download(json_data.get('extrafanart'), path, number, filepath)
 
         # 裁剪图
-        cutImage(imagecut, path, fanart_path, poster_path)
+        cutImage(imagecut, path, fanart_path, poster_path, bool(conf.face_uncensored_only() and not uncensored))
 
         # 添加水印
         if conf.is_watermark():

--- a/core.py
+++ b/core.py
@@ -491,7 +491,7 @@ def add_to_pic(pic_path, img_pic, size, count, mode):
 # ========================结束=================================
 
 
-def paste_file_to_folder(filepath, path, number, leak_word, c_word, hack_word):  # 文件路径，番号，后缀，要移动至的位置
+def paste_file_to_folder(filepath, path, multi_part, number, part, leak_word, c_word, hack_word):  # 文件路径，番号，后缀，要移动至的位置
     filepath_obj = pathlib.Path(filepath)
     houzhui = filepath_obj.suffix
     try:
@@ -524,6 +524,8 @@ def paste_file_to_folder(filepath, path, number, leak_word, c_word, hack_word): 
         sub_res = [subext.lower() for subext in config.getInstance().sub_rule()]
         for subfile in filepath_obj.parent.glob('**/*'):
             if subfile.is_file() and subfile.suffix.lower() in sub_res:
+                if multi_part and part.lower() not in subfile.name.lower():
+                    continue
                 sub_targetpath = Path(path) / f"{number}{leak_word}{c_word}{hack_word}{''.join(subfile.suffixes)}"
                 if link_mode not in (1, 2):
                     shutil.move(str(subfile), str(sub_targetpath))
@@ -573,6 +575,8 @@ def paste_file_to_folder_mode2(filepath, path, multi_part, number, part, leak_wo
         sub_res = [subext.lower() for subext in config.getInstance().sub_rule()]
         for subfile in filepath_obj.parent.glob('**/*'):
             if subfile.is_file() and subfile.suffix.lower() in sub_res:
+                if multi_part and part.lower() not in subfile.name.lower():
+                    continue
                 sub_targetpath = Path(path) / f"{number}{leak_word}{c_word}{hack_word}{''.join(subfile.suffixes)}"
                 if link_mode not in (1, 2):
                     shutil.move(str(subfile), str(sub_targetpath))
@@ -589,18 +593,6 @@ def paste_file_to_folder_mode2(filepath, path, multi_part, number, part, leak_wo
         return
     except OSError as oserr:
         print(f'[-]OS Error errno  {oserr.errno}')
-        return
-
-
-def get_part(filepath):
-    try:
-        if re.search('-CD\d+', filepath):
-            return re.findall('-CD\d+', filepath)[0]
-        if re.search('-cd\d+', filepath):
-            return re.findall('-cd\d+', filepath)[0]
-    except:
-        print("[-]failed!Please rename the filename again!")
-        moveFailedFolder(filepath)
         return
 
 
@@ -657,9 +649,9 @@ def core_main(file_path, number_th, oCC):
     imagecut =  json_data.get('imagecut')
     tag =  json_data.get('tag')
     # =======================================================================判断-C,-CD后缀
-    if '-CD' in filepath or '-cd' in filepath:
+    if re.search('-CD\d+', filepath, re.IGNORECASE):
         multi_part = 1
-        part = get_part(filepath)
+        part = re.findall('-CD\d+', filepath, re.IGNORECASE)[0]
     if '-c.' in filepath or '-C.' in filepath or '中文' in filepath or '字幕' in filepath:
         cn_sub = '1'
         c_word = '-C'  # 中文字幕影片后缀
@@ -732,7 +724,7 @@ def core_main(file_path, number_th, oCC):
             add_mark(os.path.join(path,poster_path), os.path.join(path,thumb_path), cn_sub, leak, uncensored, hack)
 
         # 移动电影
-        paste_file_to_folder(filepath, path, number, leak_word, c_word, hack_word)
+        paste_file_to_folder(filepath, path, multi_part, number, part, leak_word, c_word, hack_word)
 
         # 最后输出.nfo元数据文件，以完成.nfo文件创建作为任务成功标志
         print_files(path, leak_word, c_word,  json_data.get('naming_rule'), part, cn_sub, json_data, filepath, tag,  json_data.get('actor_list'), liuchu, uncensored, hack_word

--- a/core.py
+++ b/core.py
@@ -652,8 +652,7 @@ def core_main_no_net_op(movie_path, number):
     full_nfo = Path(path) / f"{prestr}{part}.nfo"
 
     if full_nfo.is_file():
-        nfo = full_nfo.read_text(encoding='utf-8')
-        if nfo.find(r'<tag>无码</tag>'):
+        if full_nfo.read_text(encoding='utf-8').find(r'<tag>无码</tag>') >= 0:
             uncensored = 1
     else:
         return

--- a/core.py
+++ b/core.py
@@ -10,6 +10,7 @@ from PIL import Image
 from io import BytesIO
 from pathlib import Path
 from datetime import datetime
+from lxml import etree
 
 from ADC_function import *
 from WebCrawler import get_data_from_json
@@ -291,6 +292,12 @@ def print_files(path, leak_word, c_word, naming_rule, part, cn_sub, json_data, f
                 print(f"[-]Fatal error! can not make folder '{path}'")
                 sys.exit(0)
 
+        old_nfo = None
+        try:
+            if os.path.isfile(nfo_path):
+                old_nfo = etree.parse(nfo_path)
+        except:
+            pass
         # KODI内查看影片信息时找不到number，配置naming_rule=number+'#'+title虽可解决
         # 但使得标题太长，放入时常为空的outline内会更适合，软件给outline留出的显示版面也较大
         outline = f"{number}#{outline}"
@@ -354,11 +361,17 @@ def print_files(path, leak_word, c_word, naming_rule, part, cn_sub, json_data, f
             print("  <premiered>" + release + "</premiered>", file=code)
             print("  <releasedate>" + release + "</releasedate>", file=code)
             print("  <release>" + release + "</release>", file=code)
+            if old_nfo:
+                try:
+                    xur = old_nfo.xpath('//userrating/text()')[0]
+                    if isinstance(xur, str) and re.match('\d+\.\d+|\d+', xur.strip()):
+                        print(f"  <userrating>{xur.strip()}</userrating>", file=code)
+                except:
+                    pass
             try:
                 f_rating = json_data['用户评分']
                 uc = json_data['评分人数']
-                print(f"""  <userrating>{round(f_rating * 2.0)}</userrating>
-  <rating>{round(f_rating * 2.0, 1)}</rating>
+                print(f"""  <rating>{round(f_rating * 2.0, 1)}</rating>
   <criticrating>{round(f_rating * 20.0, 1)}</criticrating>
   <ratings>
     <rating name="javdb" max="5" default="true">

--- a/core.py
+++ b/core.py
@@ -705,8 +705,9 @@ def core_main(movie_path, number_th, oCC):
 
     # 判断是否无码
     uncensored = 1 if is_uncensored(number) else 0
-    if json_data.get('无码'):
-        uncensored = 1
+    unce = json_data.get('无码')
+    if type(unce) is bool:
+        uncensored = 1 if unce else 0
 
     if '流出' in movie_path or 'uncensored' in movie_path:
         liuchu = '流出'

--- a/core.py
+++ b/core.py
@@ -629,8 +629,9 @@ def core_main_no_net_op(movie_path, number):
     path = str(Path(movie_path).parent)
 
     if re.search('-CD\d+', movie_path, re.IGNORECASE):
-        part = re.findall('-CD\d+', movie_path, re.IGNORECASE)[0]
-    if '-c.' in movie_path or '-C.' in movie_path or '中文' in movie_path or '字幕' in movie_path:
+        part = re.findall('-CD\d+', movie_path, re.IGNORECASE)[0].upper()
+    if re.search(r'-C(\.\w+$|-\w+)|\d+ch(\.\w+$|-\w+)', movie_path,
+            re.I) or '中文' in movie_path or '字幕' in movie_path:
         cn_sub = '1'
         c_word = '-C'  # 中文字幕影片后缀
     uncensored = 1 if is_uncensored(number) else 0
@@ -699,8 +700,9 @@ def core_main(movie_path, number_th, oCC):
     # =======================================================================判断-C,-CD后缀
     if re.search('-CD\d+', movie_path, re.IGNORECASE):
         multi_part = 1
-        part = re.findall('-CD\d+', movie_path, re.IGNORECASE)[0]
-    if '-c.' in movie_path or '-C.' in movie_path or '中文' in movie_path or '字幕' in movie_path:
+        part = re.findall('-CD\d+', movie_path, re.IGNORECASE)[0].upper()
+    if re.search(r'-C(\.\w+$|-\w+)|\d+ch(\.\w+$|-\w+)', movie_path,
+            re.I) or '中文' in movie_path or '字幕' in movie_path:
         cn_sub = '1'
         c_word = '-C'  # 中文字幕影片后缀
 

--- a/core.py
+++ b/core.py
@@ -71,11 +71,11 @@ def get_info(json_data):  # 返回json里的数据
 
 
 def small_cover_check(path, filename, cover_small, movie_path):
-    full_filepath = os.path.join(path, filename)
-    if config.getInstance().download_only_missing_images() and not file_not_exist_or_empty(full_filepath):
+    full_filepath = Path(path) / filename
+    if config.getInstance().download_only_missing_images() and not file_not_exist_or_empty(str(full_filepath)):
         return
     download_file_with_filename(cover_small, filename, path, movie_path)
-    print('[+]Image Downloaded! ' + full_filepath)
+    print('[+]Image Downloaded! ' + full_filepath.name)
 
 
 def create_folder(json_data):  # 创建文件夹
@@ -216,7 +216,7 @@ def extrafanart_download_one_by_one(data, path, filepath):
                 break
         if file_not_exist_or_empty(jpg_fullpath):
             return
-        print('[+]Image Downloaded!', jpg_fullpath)
+        print('[+]Image Downloaded!', Path(jpg_fullpath).name)
         j += 1
     if conf.debug():
         print(f'[!]Extrafanart download one by one mode runtime {time.perf_counter() - tm_start:.3f}s')
@@ -247,7 +247,7 @@ def extrafanart_download_threadpool(url_list, save_dir, number):
     if failed: # 非致命错误，电影不移入失败文件夹，将来可以用模式3补齐
         print(f"[-]Failed downloaded {failed}/{len(result)} extrafanart images for [{number}] to '{extrafanart_dir}', you may retry run mode 3 later.")
     else:
-        print(f"[+]Successfully downloaded {len(result)} extrafanart to '{extrafanart_dir}'")
+        print(f"[+]Successfully downloaded {len(result)} extrafanarts.")
     if conf.debug():
         print(f'[!]Extrafanart download ThreadPool mode runtime {time.perf_counter() - tm_start:.3f}s')
 
@@ -276,7 +276,7 @@ def image_download(cover, fanart_path, thumb_path, path, filepath):
             break
     if file_not_exist_or_empty(full_filepath):
         return
-    print('[+]Image Downloaded!', full_filepath)
+    print('[+]Image Downloaded!', Path(full_filepath).name)
     shutil.copyfile(full_filepath, os.path.join(path, thumb_path))
 
 
@@ -529,10 +529,10 @@ def paste_file_to_folder(filepath, path, multi_part, number, part, leak_word, c_
                 sub_targetpath = Path(path) / f"{number}{leak_word}{c_word}{hack_word}{''.join(subfile.suffixes)}"
                 if link_mode not in (1, 2):
                     shutil.move(str(subfile), str(sub_targetpath))
-                    print(f"[+]Sub Moved!  '{sub_targetpath.name}'")
+                    print(f"[+]Sub Moved!        {sub_targetpath.name}")
                 else:
                     shutil.copyfile(str(subfile), str(sub_targetpath))
-                    print(f"[+]Sub Copied!  '{sub_targetpath.name}'")
+                    print(f"[+]Sub Copied!       {sub_targetpath.name}")
         return
 
     except FileExistsError as fee:
@@ -580,10 +580,10 @@ def paste_file_to_folder_mode2(filepath, path, multi_part, number, part, leak_wo
                 sub_targetpath = Path(path) / f"{number}{leak_word}{c_word}{hack_word}{''.join(subfile.suffixes)}"
                 if link_mode not in (1, 2):
                     shutil.move(str(subfile), str(sub_targetpath))
-                    print(f"[+]Sub Moved!  '{sub_targetpath.name}'")
+                    print(f"[+]Sub Moved!        {sub_targetpath.name}")
                 else:
                     shutil.copyfile(str(subfile), str(sub_targetpath))
-                    print(f"[+]Sub Copied!  '{sub_targetpath.name}'")
+                    print(f"[+]Sub Copied!       {sub_targetpath.name}")
         return
     except FileExistsError as fee:
         print(f'[-]FileExistsError: {fee}')

--- a/core.py
+++ b/core.py
@@ -608,7 +608,7 @@ def debug_print(data: json):
             if i == 'extrafanart':
                 print('[+]  -', "%-14s" % i, ':', len(v), 'links')
                 continue
-            print('[+]  -', "%-14s" % i, ':', v)
+            print(f'[+]  - {i:<{cnspace(i,14)}} : {v}')
 
         print("[+] ------- DEBUG INFO -------")
     except:

--- a/core.py
+++ b/core.py
@@ -521,7 +521,7 @@ def paste_file_to_folder(filepath, path, multi_part, number, part, leak_word, c_
             except:
                 os.symlink(str(filepath_obj.resolve()), targetpath)
 
-        sub_res = [subext.lower() for subext in config.getInstance().sub_rule()]
+        sub_res = config.getInstance().sub_rule()
         for subfile in filepath_obj.parent.glob('**/*'):
             if subfile.is_file() and subfile.suffix.lower() in sub_res:
                 if multi_part and part.lower() not in subfile.name.lower():
@@ -572,7 +572,7 @@ def paste_file_to_folder_mode2(filepath, path, multi_part, number, part, leak_wo
             except:
                 os.symlink(str(filepath_obj.resolve()), targetpath)
 
-        sub_res = [subext.lower() for subext in config.getInstance().sub_rule()]
+        sub_res = config.getInstance().sub_rule()
         for subfile in filepath_obj.parent.glob('**/*'):
             if subfile.is_file() and subfile.suffix.lower() in sub_res:
                 if multi_part and part.lower() not in subfile.name.lower():

--- a/number_parser.py
+++ b/number_parser.py
@@ -161,7 +161,7 @@ if __name__ == "__main__":
         "sbw99.cc@iesp-653-4K.mp4",
         "4K-ABP-358_C.mkv",
         "n1012-CD1.wmv",
-        "東热n1012-CD2.wmv",
+        "[]n1012-CD2.wmv",
     )
 
 

--- a/number_parser.py
+++ b/number_parser.py
@@ -52,6 +52,8 @@ def get_number(debug: bool, file_path: str) -> str:
                 return str(re.search(r'\w+', filename[:filename.find('.')], re.A).group())
             file_number = str(re.search(r'\w+(-|_)\w+', filename, re.A).group())
             file_number = re.sub("(-|_)c$", "", file_number, flags=re.IGNORECASE)
+            if re.search("\d+ch$", file_number, flags=re.I):
+                file_number = file_number[:-2]
             return file_number.upper()
         else:  # 提取不含减号-的番号，FANZA CID
             # 欧美番号匹配规则
@@ -149,12 +151,12 @@ if __name__ == "__main__":
         "caribean-020317_001.nfo",  # -号误命名为_号的
         "257138_3xplanet_1Pondo_080521_001.mp4",
         "ADV-R0624-CD3.wmv",  # 多碟影片
-        "XXX-AV   22061-CD5.iso",  # 新支持片商格式 xxx-av-22061 命名规则来自javdb数据源
+        "XXX-AV   22061-CD5.iso",  # 支持片商格式 xxx-av-22061 命名规则来自javdb数据源
         "xxx-av 20589.mp4",
-        "Muramura-102114_145-HD.wmv",  # 新支持片商格式 102114_145  命名规则来自javdb数据源
-        "heydouga-4102-023-CD2.iso",  # 新支持片商格式 heydouga-4102-023 命名规则来自javdb数据源
+        "Muramura-102114_145-HD.wmv",  # 支持片商格式 102114_145  命名规则来自javdb数据源
+        "heydouga-4102-023-CD2.iso",  # 支持片商格式 heydouga-4102-023 命名规则来自javdb数据源
         "HeyDOuGa4236-1048 Ai Qiu - .mp4",  # heydouga-4236-1048 命名规则来自javdb数据源
-        "pacopacomama-093021_539-FHD.mkv",  # 新支持片商格式 093021_539 命名规则来自javdb数据源
+        "pacopacomama-093021_539-FHD.mkv",  # 支持片商格式 093021_539 命名规则来自javdb数据源
         "sbw99.cc@heyzo_hd_2636_full.mp4",
         "hhd800.com@STARS-566-HD.mp4",
         "jav20s8.com@GIGL-677_4K.mp4",
@@ -162,6 +164,10 @@ if __name__ == "__main__":
         "4K-ABP-358_C.mkv",
         "n1012-CD1.wmv",
         "[]n1012-CD2.wmv",
+        "rctd-460ch.mp4",  # 除支持-C硬字幕外，新支持ch硬字幕
+        "rctd-461CH-CD2.mp4",  # ch后可加CDn
+        "rctd-461-Cd3-C.mp4",  # CDn后可加-C
+        "rctd-461-C-cD4.mp4",  # cD1 Cd1 cd1 CD1 最终生成.nfo时统一为大写CD1
     )
 
 

--- a/number_parser.py
+++ b/number_parser.py
@@ -48,6 +48,8 @@ def get_number(debug: bool, file_path: str) -> str:
             if 'fc2' in lower_check:
                 filename = lower_check.replace('ppv', '').replace('--', '-').replace('_', '-').upper()
             filename = re.sub("(-|_)cd\d{1,2}", "", filename, flags=re.IGNORECASE)
+            if not re.search("-|_", filename): # 去掉-CD1之后再无-的情况，例如n1012-CD1.wmv
+                return str(re.search(r'\w+', filename[:filename.find('.')], re.A).group())
             file_number = str(re.search(r'\w+(-|_)\w+', filename, re.A).group())
             file_number = re.sub("(-|_)c$", "", file_number, flags=re.IGNORECASE)
             return file_number.upper()
@@ -157,7 +159,9 @@ if __name__ == "__main__":
         "hhd800.com@STARS-566-HD.mp4",
         "jav20s8.com@GIGL-677_4K.mp4",
         "sbw99.cc@iesp-653-4K.mp4",
-        "4K-ABP-358_C.mkv"
+        "4K-ABP-358_C.mkv",
+        "n1012-CD1.wmv",
+        "東热n1012-CD2.wmv",
     )
 
 

--- a/number_parser.py
+++ b/number_parser.py
@@ -5,7 +5,7 @@ import config
 import typing
 
 G_spat = re.compile(
-    "^\w+\.(cc|com)@|^22-sht\.me|"
+    "^\w+\.(cc|com|net|me|club|jp|tv|xyz|biz|wiki|info|tw|us|de)@|^22-sht\.me|"
     "^(fhd|hd|sd|1080p|720p|4K)(-|_)|"
     "(-|_)(fhd|hd|sd|1080p|720p|4K|uncensored|leak)",
     re.IGNORECASE)

--- a/number_parser.py
+++ b/number_parser.py
@@ -47,7 +47,7 @@ def get_number(debug: bool, file_path: str) -> str:
             lower_check = filename.lower()
             if 'fc2' in lower_check:
                 filename = lower_check.replace('ppv', '').replace('--', '-').replace('_', '-').upper()
-            filename = re.sub("(-|_)cd\d{1,2}", "", filename, flags=re.IGNORECASE)
+            filename = re.sub("-cd\d{1,2}", "", filename, flags=re.IGNORECASE)
             if not re.search("-|_", filename): # 去掉-CD1之后再无-的情况，例如n1012-CD1.wmv
                 return str(re.search(r'\w+', filename[:filename.find('.')], re.A).group())
             file_number = str(re.search(r'\w+(-|_)\w+', filename, re.A).group())

--- a/number_parser.py
+++ b/number_parser.py
@@ -5,8 +5,9 @@ import config
 import typing
 
 G_spat = re.compile(
-    "^22-sht\.me|-fhd|_fhd|^fhd_|^fhd-|-hd|_hd|^hd_|^hd-|-sd|_sd|-1080p|_1080p|-720p|_720p|"
-    "^\w+\.(cc|com)@|-uncensored|_uncensored|-leak|_leak|-4K|_4K",
+    "^\w+\.(cc|com)@|^22-sht\.me|"
+    "^(fhd|hd|sd|1080p|720p|4K)(-|_)|"
+    "(-|_)(fhd|hd|sd|1080p|720p|4K|uncensored|leak)",
     re.IGNORECASE)
 
 
@@ -153,9 +154,10 @@ if __name__ == "__main__":
         "HeyDOuGa4236-1048 Ai Qiu - .mp4",  # heydouga-4236-1048 命名规则来自javdb数据源
         "pacopacomama-093021_539-FHD.mkv",  # 新支持片商格式 093021_539 命名规则来自javdb数据源
         "sbw99.cc@heyzo_hd_2636_full.mp4",
-        "hhd800.com@STARS-566.mp4",
-        "jav20s8.com@GIGL-677.mp4",
-        "sbw99.cc@iesp-653.mp4"
+        "hhd800.com@STARS-566-HD.mp4",
+        "jav20s8.com@GIGL-677_4K.mp4",
+        "sbw99.cc@iesp-653-4K.mp4",
+        "4K-ABP-358_C.mkv"
     )
 
 


### PR DESCRIPTION
已有的`-c`和`-d`参数可用于少量多次处理电影文件，但需要脚本配合。

新增`-R`或`--rerun-delay`参数，及配置文件`[common]`小节`rerun_dealy=`选项。
参数优先，使用参数时将覆盖配置文件中的设置。此项必须在`-c`参数或者配置文件`stop_counter=`非0时方生效。
本功能生效时，会在首次运行后并不退出，等待指定时间后再次运行刮削，直到指定目录全部处理完成方才退出。至此不再需要用户编写额外的脚本来支持多次少量运行的功能（自编脚本依然支持，且可以进行更复杂的日志分析，来完成各自的定制需求）。
时间语法 纯数字(秒) 或者 h时m分s秒 不分先后次序，中间不能有空格，例如: 
`-R 1h30m45s` 1小时30分45秒
`-R 45` 45秒
```ini
[common]
; 1+1+3+60=65秒
rerun_dealy=1s1s3s1m

```
执行方法示例：以模式3方式，每次处理5部影片，影片上次刮削或更新.nfo时间需要在30天以前，每隔10分钟(9分60秒)再次运行，以免频繁请求被封禁IP，直到电影全部处理完成。
```
mdc.exe -c 5 -d 30 -R 9m60s -m 3 -p D:\jav
```

警告：设置参数`-d0`或者`-id0`，将导致重复刮削的死循环（按Ctrl+C可终止运行）。