### PR TITLE
解决PLEX演员头像问题（仍需搭配 XBMCnfoMoviesImporter.bundle 使用）

### DIFF
--- a/core.py
+++ b/core.py
@@ -368,6 +368,8 @@ def print_files(path, leak_word, c_word, naming_rule, part, cn_sub, json_data, f
                 for key in actor_list:
                     print("  <actor>", file=code)
                     print("    <name>" + key + "</name>", file=code)
+                    print("    <role>Protagonist</role>", file=code)
+                    print("    <thumb>" + actor_photo.get(str(key)) + "</thumb>", file=code)
                     print("  </actor>", file=code)
             except:
                 aaaa = ''


### PR DESCRIPTION
在PLEX上测试了没有问题。但我猜在emby/jellyfin上也有用，而不需要 Gfriends 了