### PR TITLE
支持用本地gfriends库补全影片库KODI头像

### DIFF
--- a/WebCrawler/airav.py
+++ b/WebCrawler/airav.py
@@ -1,7 +1,6 @@
 import sys
 sys.path.append('../')
 import re
-from pyquery import PyQuery as pq#need install
 from lxml import etree#need install
 from bs4 import BeautifulSoup#need install
 import json

--- a/WebCrawler/madou.py
+++ b/WebCrawler/madou.py
@@ -2,7 +2,6 @@ import sys
 sys.path.append('../')
 from bs4 import BeautifulSoup  # need install
 from lxml import etree  # need install
-from pyquery import PyQuery as pq  # need install
 from ADC_function import *
 import json
 import re

--- a/WebCrawler/mv91.py
+++ b/WebCrawler/mv91.py
@@ -1,7 +1,6 @@
 import sys
 sys.path.append('../')
 import re
-from pyquery import PyQuery as pq#need install
 from lxml import etree#need install
 from bs4 import BeautifulSoup#need install
 import json
@@ -78,7 +77,7 @@ def getOutline(html):  #获取概述
         return result.strip()
     except:
         return ''
-  
+
 
 def getSerise(htmlcode):   #获取系列 已修改
     return ''
@@ -112,11 +111,11 @@ def main(number):
             'year': getYear(html),
             # 简介
             'outline': getOutline(html),
-            # 
+            #
             'runtime': getRuntime(html),
-            # 导演 
+            # 导演
             'director': getDirector(html),
-            # 演员 
+            # 演员
             'actor': getActor(html),
             # 发售日
             'release': getRelease(html),
@@ -127,9 +126,9 @@ def main(number):
             # 剧照获取
             'extrafanart': getExtrafanart(html),
             'imagecut': 1,
-            # 
+            #
             'tag': getTag(html),
-            # 
+            #
             'label': getSerise(html),
             # 作者图片
             'website': url,

--- a/config.ini
+++ b/config.ini
@@ -134,3 +134,4 @@ multi_part_fanart=0
 
 [actor_photo]
 download_for_kodi=0
+gfriends_path=

--- a/config.ini
+++ b/config.ini
@@ -92,6 +92,7 @@ water=2
 switch=1
 parallel_download=5
 extrafanart_folder=extrafanart
+unzip_gallery=1
 
 ; 剧情简介
 [storyline]

--- a/config.py
+++ b/config.py
@@ -382,6 +382,15 @@ class Config:
     def javdb_sites(self) -> str:
         return self.conf.get("javdb", "sites", fallback="38,39,40")
 
+    def javdb_urls_xpath(self) -> str:
+        return self.conf.get("javdb", "urls_xpath", fallback='//div[@class="item"]/a[@class="box"]/@href')
+
+    def javdb_ids_xpath(self) -> str:
+        return self.conf.get("javdb", "ids_xpath", fallback='//div[@class="item"]/a[@class="box"]/div[@class="video-title"]/strong/text()')
+
+    def javdb_img_site(self) -> str:
+        return self.conf.get("javdb", "img_site", fallback='jdbimgs.com')
+
     def face_locations_model(self) -> str:
         return self.conf.get("face", "locations_model", fallback="hog")
 

--- a/config.py
+++ b/config.py
@@ -380,7 +380,7 @@ class Config:
             fallback="actor,director,label,outline,series,studio,tag,title")
 
     def javdb_sites(self) -> str:
-        return self.conf.get("javdb", "sites", fallback="38,39")
+        return self.conf.get("javdb", "sites", fallback="38,39,40")
 
     def face_locations_model(self) -> str:
         return self.conf.get("face", "locations_model", fallback="hog")
@@ -399,6 +399,9 @@ class Config:
 
     def download_actor_photo_for_kodi(self) -> bool:
         return self.conf.getboolean("actor_photo", "download_for_kodi", fallback=False)
+
+    def actor_photo_gfriends_path(self) -> str:
+        return self.conf.get("actor_photo", "gfriends_path", fallback="")
 
     @staticmethod
     def _exit(sec: str) -> None:

--- a/config.py
+++ b/config.py
@@ -247,6 +247,9 @@ class Config:
         except:
             return 5
 
+    def extrafanart_unzip_gallery(self) -> bool:
+        return self.conf.getboolean("extrafanart", "unzip_gallery", fallback=True)
+
     def watermark_type(self) -> int:
         return int(self.conf.get("watermark", "water"))
 

--- a/core.py
+++ b/core.py
@@ -305,6 +305,7 @@ def actor_photo_download(actors, save_dir, number):
         # 本地gfriends库优先，没有的才从远程下载
         if not copy_from_local_gfriends(actor_name, pic_fullpath):
             dn_list.append((url, pic_fullpath))
+        else:
             local_cnt += 1
     if local_cnt:
         print(f"[+]Successfully link or copy {local_cnt} actor photo from local gfriends git repository")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && mv AV_Data_Capture-master /jav \
     && cd /jav \
     && ( pip install --no-cache-dir -r requirements.txt || true ) \
-    && pip install --no-cache-dir requests pyquery lxml Beautifulsoup4 pillow \
+    && pip install --no-cache-dir requests lxml Beautifulsoup4 pillow \
     && apt-get purge -y wget
 
 WORKDIR /jav

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,10 @@
 requests
-pyquery
 lxml
 beautifulsoup4
 pillow
 cloudscraper
-pysocks==1.7.1
-urllib3==1.24.3
-certifi==2020.12.5
-MechanicalSoup==1.1.0
+urllib3
+certifi
+MechanicalSoup>=1.1.0
 opencc-python-reimplemented
 face_recognition

--- a/wrapper/FreeBSD.sh
+++ b/wrapper/FreeBSD.sh
@@ -1,5 +1,5 @@
-pkg install python38 py38-requests py38-pip py38-lxml py38-pillow py38-cloudscraper py38-pysocks git zip py38-beautifulsoup448 py38-mechanicalsoup
-pip install pyquery pyinstaller
+pkg install python38 py38-requests py38-pip py38-lxml py38-pillow py38-cloudscraper git zip py38-beautifulsoup448 py38-mechanicalsoup
+pip install pyinstaller
 pyinstaller --onefile Movie_Data_Capture.py  --hidden-import ADC_function.py --hidden-import core.py \
     --hidden-import "ImageProcessing.cnn" \
     --add-data "$(python3.8 -c 'import cloudscraper as _; print(_.__path__[0])' | tail -n 1):cloudscraper" \


### PR DESCRIPTION
* ### 清理未使用模块，取消一些模块的版本号限制
去掉未使用模块: `pyquery` `pysocks`
版本号限制取消和修改： `urllib3` `certifi` `MechanicalSoup>=1.1.0`

* ### 支持用本地gfriends库补全影片库KODI头像
需要设置`download_for_kodi=1`且gfriends_path=为克隆到本地的gfriends仓库路径。
克隆gfriends到本地的MSYS2命令行：`git clone --depth 1 https://github.com/xinxin8816/gfriends.git d:/git/gfriends`
这个仓库较大(>6GB)请量力而行。配置文件示例如下：
```ini
[actor_photo]
download_for_kodi=1
gfriends_path=d:/git/gfriends
```
示例：不联网方式补全影片库中没有头像的全部视频：
`mdc -Nm3 -d0 -C "actor_photo:download_for_kodi=1;gfriends_path=d:/git/gfriends" -p 影片库路径`

示例：不联网以gfriends仓库图片，新增和替换全影片库全部KODI头像（注意：从javdb等网站下载的头像也将被全部覆盖为gfriends仓库的头像，javdb等网站主要为头像，gfriends仓库主要为全身图，请按自身需要取舍)：
`mdc -D -Nm3 -d0 -C "actor_photo:download_for_kodi=1;gfriends_path=d:/git/gfriends" -p 影片库路径`

* ### javdb urls/ids xpath和图片站域名可通过配置文件修改
新增以下默认值，暂时不出现在config.ini中以免用户随意改动，反而造成其无法正常使用，如遇javdb改版，可通过公布修改config.ini中的对应xpath和域名的修改方法，临时解决而无需发布新版本。
```ini
[javdb]
urls_xpath=//div[@class="item"]/a[@class="box"]/@href
ids_xpath=//div[@class="item"]/a[@class="box"]/div[@class="video-title"]/strong/text()
img_site=jdbimgs.com
```

* ### 新增刮削时搬运剧照压缩包gallery*.zip，以及解压剧照选项
JavDB等网站虽然提供剧照下载，但通常非付费会员只能下载小部分剧照。用户BT下载时，如果下载目录中已经存在剧照压缩包，则在刮削时会将其搬运到目标目录。剧照压缩包中的剧照图片，往往比网站下载的数量更多，质量更高。
提供了压缩包剧照的解压缩选项`unzip_gallery=1`，默认开启，仅当剧照下载`switch=1`功能开启时才会生效。
```ini
; 剧照
[extrafanart]
switch=1
unzip_gallery=1
```
![image](https://user-images.githubusercontent.com/30518126/167282323-27b682b8-fa00-4084-88d2-45627d9604bc.png)

```
PS Z:\> tree o /F
Z:\O
└─#ゆずき
    └─[2015] まんこ屋～新入社員はヤル気マンマン！～ - ゆずき [HEYZO-0897]
        │  gallery_0897.zip
        │  HEYZO-0897-fanart.jpg
        │  HEYZO-0897-poster.jpg
        │  HEYZO-0897-thumb.jpg
        │  HEYZO-0897.mp4
        │  HEYZO-0897.nfo
        │
        └─extrafanart
            └─gallery_0897
                    001.jpg
                    002.jpg
                    003.jpg
                    004.jpg
                    005.jpg
                    006.jpg
                    007.jpg
                    008.jpg
                    009.jpg
                    010.jpg
                    011.jpg
                    012.jpg
                    013.jpg
                    014.jpg
                    015.jpg
                    016.jpg
                    017.jpg
                    018.jpg
                    019.jpg
                    020.jpg
                    021.jpg
```
