### PR TITLE
Update getchu.py

### DIFF
--- a/scrapinglib/getchu.py
+++ b/scrapinglib/getchu.py
@@ -121,7 +121,7 @@ class dlGetchu(wwwGetchu):
         if "item" in number or 'GETCHU' in number.upper():
             self.number = re.findall('\d+',number)[0]
         else:
-            queryUrl = self.GETCHU_DL_SEARCH_URL.replace("_WORD_", number)
+            queryUrl = self.GETCHU_DL_SEARCH_URL.replace("_WORD_", quote(number, encoding="euc_jp"))
             queryTree = self.getHtmlTree(queryUrl)
             detailurl = self.getTreeElement(queryTree, '/html/body/div[1]/table/tr/td/table[4]/tr/td[2]/table/tr[2]/td/table/tr/td/table/tr/td[2]/div/a[1]/@href')
             if detailurl == "":


### PR DESCRIPTION
解决如果文件中包含需要url编码的字符时，getchu匹配到无关结果的问题
问题url：http://www.getchu.com/php/search.phtml?genre=anime_dvd&search_keyword=本編%20通常ver&check_key_dtl=1&submit=
修复后正确url：http://www.getchu.com/php/search.phtml?genre=anime_dvd&search_keyword=%CB%DC%CA%D4%20%C4%CC%BE%EFverver&check_key_dtl=1&submit=

**本人无python开发经验，本地也无开发环境，本段代码取自同文件54行处，合并时请复查语法等是否无误**