### PR TITLE
add -u option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           pyinstaller \
             --onefile Movie_Data_Capture.py \
+            --python-option u \
             --hidden-import "ImageProcessing.cnn" \
             --add-data "$(python -c 'import cloudscraper as _; print(_.__path__[0])' | tail -n 1):cloudscraper" \
             --add-data "$(python -c 'import opencc as _; print(_.__path__[0])' | tail -n 1):opencc" \
@@ -51,6 +52,7 @@ jobs:
         run: |
           pyinstaller `
             --onefile Movie_Data_Capture.py `
+            --python-option u `
             --hidden-import "ImageProcessing.cnn" `
             --add-data "$(python -c 'import cloudscraper as _; print(_.__path__[0])' | tail -n 1);cloudscraper" `
             --add-data "$(python -c 'import opencc as _; print(_.__path__[0])' | tail -n 1);opencc" `


### PR DESCRIPTION
When using PyInstaller created release with docker, the log will be bufferred and cannot be enabled using `PYTHONUNBUFFERED=True` environment.  Then I tried to build the release with `-u` command with `PyInstaller`, it works pretty good. I think it would be nice that we can package the release with `-u` enabled by default .

PyInstaller Doc: https://pyinstaller.org/en/stable/usage.html#cmdoption-python-option