### PR TITLE
Fix: #912(PATCH)

### DIFF
--- a/core.py
+++ b/core.py
@@ -344,11 +344,11 @@ def print_files(path, leak_word, c_word, naming_rule, part, cn_sub, json_data, f
             print("<movie>", file=code)
             if not config.getInstance().jellyfin():
                 print("  <title><![CDATA[" + naming_rule + "]]></title>", file=code)
-                print("  <originaltitle><![CDATA[" + naming_rule + "]]></originaltitle>", file=code)
+                print("  <originaltitle><![CDATA[" + json_data['original_naming_rule'] + "]]></originaltitle>", file=code)
                 print("  <sorttitle><![CDATA[" + naming_rule + "]]></sorttitle>", file=code)
             else:
                 print("  <title>" + naming_rule + "</title>", file=code)
-                print("  <originaltitle>" + naming_rule + "</originaltitle>", file=code)
+                print("  <originaltitle>" + json_data['original_naming_rule'] + "</originaltitle>", file=code)
                 print("  <sorttitle>" + naming_rule + "</sorttitle>", file=code)    
             print("  <customrating>JP-18+</customrating>", file=code)
             print("  <mpaa>JP-18+</mpaa>", file=code)

--- a/scraper.py
+++ b/scraper.py
@@ -269,14 +269,22 @@ def get_data_from_json(
                     pass
 
     naming_rule = ""
+    original_naming_rule = ""
     for i in conf.naming_rule().split("+"):
         if i not in json_data:
             naming_rule += i.strip("'").strip('"')
+            original_naming_rule += i.strip("'").strip('"')
         else:
             item = json_data.get(i)
             naming_rule += item if type(item) is not list else "&".join(item)
+            # PATCH：处理[title]存在翻译的情况，后续NFO文件的original_name只会直接沿用naming_rule,这导致original_name非原始名
+            # 理应在翻译处处理 naming_rule和original_naming_rule
+            if i == 'title':
+                item = json_data.get('original_title')
+            original_naming_rule += item if type(item) is not list else "&".join(item)
 
     json_data['naming_rule'] = naming_rule
+    json_data['original_naming_rule'] = original_naming_rule
     return json_data
 
 


### PR DESCRIPTION
解决 issue #912 中修复翻译title导致NFO文件中的`originaltitle`也会一起被翻译的问题（该问题直到6.5.1仍然没有解决）。

另， 因为是通过打补丁的方式暂时解决该问题，可能会出现以下问题：
`originaltitle`中的其他部分仍然是被翻译的，例如：`MIDE-622 付き合いたての彼氏の目の前で追撃レ×プ輪●でイキすぎてしまった敏感女子大生 二宫光`

如果需要彻底解决该问题，则翻译时不应该修改`json_data`中已有内容，而是应该新加`item`存储翻译后的内容，并在写入NFO文件时根据是否翻译调取不同的数据。

---

修改前：

```
  <title>TAAK-024 在女仆咖啡厅打工的美美是台湾交换生，遭到性骚扰。</title>
  <originaltitle>TAAK-024 在女仆咖啡厅打工的美美是台湾交换生，遭到性骚扰。</originaltitle>
  <sorttitle>TAAK-024 在女仆咖啡厅打工的美美是台湾交换生，遭到性骚扰。</sorttitle>
```

修改后：
```
  <title>TAAK-024 在女仆咖啡厅打工的美美是台湾交换生，遭到性骚扰。</title>
  <originaltitle>TAAK-024 メイド喫茶でバイトするメイメイちゃんはセクハラされまくりの台湾人留学生</originaltitle>
  <sorttitle>TAAK-024 在女仆咖啡厅打工的美美是台湾交换生，遭到性骚扰。</sorttitle>
```
