### PR TITLE
Should return 404 for api to handle

### DIFF
--- a/scrapinglib/parser.py
+++ b/scrapinglib/parser.py
@@ -85,7 +85,7 @@ class Parser:
         else:
             self.detailurl = self.queryNumberUrl(number)
         if not self.detailurl:
-            return None
+            return 404
         htmltree = self.getHtmlTree(self.detailurl)
         result = self.dictformat(htmltree)
         return result


### PR DESCRIPTION
None can't be handled correctly by [api.py](https://github.com/yoshiko2/Movie_Data_Capture/blob/181672324ee9703dcff68c55d8d2df6cd2927bb2/scrapinglib/api.py#L87-L90)

