### PR TITLE
Fixed javdb while loop

### DIFF
--- a/scrapinglib/api.py
+++ b/scrapinglib/api.py
@@ -149,23 +149,16 @@ class Scraping:
         # javdb的封面有水印，如果可以用其他源的封面来替换javdb的封面
         if 'source' in json_data and json_data['source'] == 'javdb':
             # search other sources
-            other_sources = sources[sources.index('javdb') + 1:]
-            while other_sources:
-                # If cover not found in other source, then skip using other sources using javdb cover instead
-                try:
-                    other_json_data = self.searchAdult(number, other_sources)
-                    if other_json_data is not None and 'cover' in other_json_data and other_json_data['cover'] != '':
-                        json_data['cover'] = other_json_data['cover']
-                        if self.debug:
-                            print(f"[+]Find movie [{number}] cover on website '{other_json_data['cover']}'")
-                        break
-                    # 当不知道source为何时，只能停止搜索
-                    if 'source' not in other_json_data:
-                        break
-                    # check other sources
-                    other_sources = sources[sources.index(other_json_data['source']) + 1:]
-                except:
-                    pass
+            # If cover not found in other source, then skip using other sources using javdb cover instead
+            try:
+                other_sources = sources[sources.index('javdb') + 1:]
+                other_json_data = self.searchAdult(number, other_sources)
+                if other_json_data is not None and 'cover' in other_json_data and other_json_data['cover'] != '':
+                    json_data['cover'] = other_json_data['cover']
+                    if self.debug:
+                        print(f"[+]Find movie [{number}] cover on website '{other_json_data['cover']}'")
+            except:
+                pass
 
         # Return if data not found in all sources
         if not json_data or json_data['title'] == "":


### PR DESCRIPTION
經測試如果影片只在Javdb有，會進入死循環。 番號例：SJC-03。
因為other_sources在other_json_data = self.searchAdult(number, other_sources)已經搜尋完畢，所以沒有使用while迴圈的必要。並且當other_json_data中沒有資料的時候if 'source' not in other_json_data:會產生錯誤，跳到except中的pass，就進入死循環了。