### PR TITLE
Only process file with suffix, not directory.

### DIFF
--- a/Movie_Data_Capture.py
+++ b/Movie_Data_Capture.py
@@ -351,6 +351,8 @@ def movie_lists(source_folder, regexstr: str) -> typing.List[str]:
     for full_name in source.glob(r'**/*'):
         if main_mode != 3 and set(full_name.parent.parts) & escape_folder_set:
             continue
+        if not full_name.is_file():
+            continue
         if not full_name.suffix.lower() in file_type:
             continue
         absf = str(full_name)


### PR DESCRIPTION
On Synology NAS, if File Index and Video Station enabled, it may generate a folder contains screenshot under @eadir.
MDC shouldn't handle that. So let's check the full_name is a file first.