### PR TITLE
对GETCHU使用指定编码"EUC-JIS-2004"("EUC-JP"编码的超集)

### DIFF
--- a/scrapinglib/getchu.py
+++ b/scrapinglib/getchu.py
@@ -69,7 +69,7 @@ class wwwGetchu(Parser):
     def getHtml(self, url, type = None):
         """ 访问网页(指定EUC-JP)
         """
-        resp = httprequest.get(url, cookies=self.cookies, proxies=self.proxies, extra_headers=self.extraheader, encoding='euc-jp', verify=self.verify, return_type=type)
+        resp = httprequest.get(url, cookies=self.cookies, proxies=self.proxies, extra_headers=self.extraheader, encoding='euc_jis_2004', verify=self.verify, return_type=type)
         if '<title>404 Page Not Found' in resp \
             or '<title>未找到页面' in resp \
             or '404 Not Found' in resp \


### PR DESCRIPTION
"EUC-JIS-2004"查资料说是基于"EUC-JP"添加了一些额外字符, 对之前提到的Issue #1049相关解析问题进行了修复.