### PR TITLE
修正airav概率性无法获取封面的问题

### DIFF
--- a/scrapinglib/airav.py
+++ b/scrapinglib/airav.py
@@ -142,6 +142,9 @@ class Airav(Parser):
             result = self.javbus.get('cover')
             if isinstance(result, str) and len(result):
                 return result
+        result = htmltree['img_url']
+        if isinstance(result, str) and len(result):
+            return result
         return super().getCover(htmltree)
 
     def getSeries(self, htmltree):


### PR DESCRIPTION
当javbus无法获取封面时，取airav的img_url作为封面