### PR TITLE
fix(sec): upgrade urllib3 to 1.26.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ beautifulsoup4
 pillow==9.5.0
 cloudscraper
 pysocks==1.7.1
-urllib3==1.25.11
+urllib3==1.26.5
 certifi
 MechanicalSoup
 opencc-python-reimplemented


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 1.25.11
- [CVE-2021-33503](https://www.oscs1024.com/hd/CVE-2021-33503)


### What did I do？
Upgrade urllib3 from 1.25.11 to 1.26.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS