### PR TITLE
fix image cut issue

### DIFF
--- a/core.py
+++ b/core.py
@@ -577,7 +577,7 @@ def add_to_pic(pic_path, img_pic, size, count, mode):
     img_subt = Image.open(mark_pic_path)
     scroll_high = int(img_pic.height / size)
     scroll_wide = int(scroll_high * img_subt.width / img_subt.height)
-    img_subt = img_subt.resize((scroll_wide, scroll_high), Image.ANTIALIAS)
+    img_subt = img_subt.resize((scroll_wide, scroll_high), Image.LANCZOS)
     r, g, b, a = img_subt.split()  # 获取颜色通道，保持png的透明性
     # 封面四个角的位置
     pos = [


### PR DESCRIPTION
剪裁图片时候报错
```
AttributeError: module 'PIL.Image' has no attribute 'ANTIALIAS'
```
会导致女优姓名无法正确输出，变为“佚名”
根据[stackoverflow的建议](https://stackoverflow.com/questions/76616042/attributeerror-module-pil-image-has-no-attribute-antialias)