### PR TITLE
支持识别WSL子系统路径

### DIFF
--- a/core.py
+++ b/core.py
@@ -17,6 +17,8 @@ from ImageProcessing import cutImage
 # from WebCrawler import get_data_from_json
 
 def escape_path(path, escape_literals: str):  # Remove escape literals
+    if path.startswith('\\\\wsl.localhost'):
+        return path
     backslash = '\\'
     for literal in escape_literals:
         path = path.replace(backslash + literal, '')


### PR DESCRIPTION
使支持识别使用WSL挂载的Ext4移动硬盘路径，例如 `\\wsl.localhost\Ubuntu\mnt\wsl\PHYSICALDRIVE3p1\Downloads`